### PR TITLE
Refactor(NicoDora/auth): 토큰 로직 authMoudule exports 설정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,3 @@
-import { TokenService } from './auth/services/token.service';
 import { UserImageService } from './users/services/user-image.service';
 import { AuthModule } from './auth/auth.module';
 import { CommentModule } from './comments/comment.module';
@@ -16,7 +15,6 @@ import { FriendsModule } from './friends/friends.module';
 import { NoticeModule } from './common/notice/notice.module';
 import * as mongoose from 'mongoose';
 import { UserImageRepository } from './users/repositories/user-image.repository';
-import { TokenRepository } from './auth/repositories/token.repository';
 
 @Module({
   imports: [
@@ -40,8 +38,6 @@ import { TokenRepository } from './auth/repositories/token.repository';
     NoticeModule,
   ], //
   providers: [
-    TokenService,
-    TokenRepository,
     UserImageService,
     UserImageRepository,
     S3Service,

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { TokenService } from './services/token.service';
 
 @Module({
   imports: [],
+  exports: [TokenService, TokenRepository],
   controllers: [AuthController],
   providers: [AuthService, TokenService, UserRepository, UserImageRepository, TokenRepository, S3Service],
 })

--- a/src/auth/repositories/token.repository.ts
+++ b/src/auth/repositories/token.repository.ts
@@ -33,7 +33,7 @@ export class TokenRepository {
 
   async deleteTokens(userId: number): Promise<Token | DeleteResult> {
     const res = await this.entityManager.delete(Token, { userId });
-    if (res.affected === 0) {
+    if (!res.affected) {
       throw new NotFoundException('토큰을 찾을 수 없습니다.');
     }
     return res;

--- a/src/friends/friends.module.ts
+++ b/src/friends/friends.module.ts
@@ -2,12 +2,11 @@ import { Module } from '@nestjs/common';
 import { FriendsController } from './controllers/friends.controller';
 import { FriendsService } from './services/friends.service';
 import { FriendsRepository } from './repositories/friends.repository';
-import { TokenService } from 'src/auth/services/token.service';
-import { TokenRepository } from 'src/auth/repositories/token.repository';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
-  imports: [],
+  imports: [AuthModule],
   controllers: [FriendsController],
-  providers: [FriendsService, FriendsRepository, TokenService, TokenRepository],
+  providers: [FriendsService, FriendsRepository],
 })
 export class FriendsModule {}

--- a/src/users/user.module.ts
+++ b/src/users/user.module.ts
@@ -8,13 +8,12 @@ import { S3Service } from 'src/common/s3/s3.service';
 import { UserRepository } from './repositories/user.repository';
 import { UserImageRepository } from './repositories/user-image.repository';
 import { UserImageService } from './services/user-image.service';
-import { TokenService } from 'src/auth/services/token.service';
-import { TokenRepository } from 'src/auth/repositories/token.repository';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User]), AuthModule],
   controllers: [UserController, UserImageController],
   providers: [
-        S3Service, UserRepository, UserImageRepository, UserService, UserImageService, TokenService, TokenRepository],
+        S3Service, UserRepository, UserImageRepository, UserService, UserImageService],
 })
 export class UserModule {}


### PR DESCRIPTION
토큰 관련 로직을 AuthModule exports로 설정하여 다른 서비스단에서 사용할 때 AuthModule만 imports 하면 사용할 수 있게 변경했습니다.

(나중엔 커스텀 데코레이터를 사용하는 것으로 변경할 예정입니다.)