### PR TITLE
Add(NicoDora/friend) : 친구 요청 취소, 친구 차단 및 차단 취소 기능 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,7 +25,7 @@ import { SearchModule } from './search/search.module';
     UserModule,
     TypeOrmModule.forRoot({
       ...TypeORMconfig, // TypeORM 설정 객체 확장
-      synchronize: true, // DB 동기화 여부 설정
+      synchronize: false, // DB 동기화 여부 설정
     }),
     // TypeOrmModule.forFeature([Image]),
     ConfigModule.forRoot({

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,7 +25,7 @@ import { SearchModule } from './search/search.module';
     UserModule,
     TypeOrmModule.forRoot({
       ...TypeORMconfig, // TypeORM 설정 객체 확장
-      synchronize: false, // DB 동기화 여부 설정
+      synchronize: true, // DB 동기화 여부 설정
     }),
     // TypeOrmModule.forFeature([Image]),
     ConfigModule.forRoot({

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,7 +25,7 @@ import { SearchModule } from './search/search.module';
     UserModule,
     TypeOrmModule.forRoot({
       ...TypeORMconfig, // TypeORM 설정 객체 확장
-      synchronize: false, // DB 동기화 여부 설정
+      synchronize: false, // DB 동기화 여부 설정
     }),
     // TypeOrmModule.forFeature([Image]),
     ConfigModule.forRoot({

--- a/src/friends/controllers/friends.controller.ts
+++ b/src/friends/controllers/friends.controller.ts
@@ -79,18 +79,6 @@ export class FriendsController {
     return await this.friendsService.friendResponseReject(userId, friendId);
   }
 
-  @ApiDeleteRejectPermanentCancel()
-  @Delete('responses/reject/permanent/:friend_id')
-  async friendResponseRejectPermanentCancel(
-    @GetUserId() userId: number,
-    @Param('friend_id') friendId: number,
-  ) {
-    return await this.friendsService.friendResponseRejectPermanentCancel(
-      userId,
-      friendId,
-    );
-  }
-
   @ApiFriendResponseRejectPermanent()
   @Patch('responses/reject/permanent/:friend_id')
   async friendResponseRejectPermanent(
@@ -98,6 +86,18 @@ export class FriendsController {
     @Param('friend_id') friendId: number,
   ) {
     return await this.friendsService.friendResponseRejectPermanent(
+      userId,
+      friendId,
+    );
+  }
+
+  @ApiDeleteRejectPermanentCancel()
+  @Delete('responses/reject/permanent/:friend_id')
+  async friendResponseRejectPermanentCancel(
+    @GetUserId() userId: number,
+    @Param('friend_id') friendId: number,
+  ) {
+    return await this.friendsService.friendResponseRejectPermanentCancel(
       userId,
       friendId,
     );

--- a/src/friends/controllers/friends.controller.ts
+++ b/src/friends/controllers/friends.controller.ts
@@ -24,6 +24,7 @@ import { GetUserId } from 'src/common/decorators/get-userId.decorator';
 import { ApiDeleteRequest } from '../swagger-decorators/delete-request.decorator';
 import { ApiFriendBlock } from '../swagger-decorators/friend-block.decorator';
 import { ApiDeleteBlock } from '../swagger-decorators/delete-block.decorator';
+import { ApiGetFriendsBlock } from '../swagger-decorators/get-friends-block.decorator';
 
 @UseGuards(JwtAccessTokenGuard)
 @Controller('friends')
@@ -47,6 +48,12 @@ export class FriendsController {
   @Get()
   async getFriends(@GetUserId() userId: number) {
     return await this.friendsService.getFriends(userId);
+  }
+
+  @ApiGetFriendsBlock()
+  @Get('block')
+  async getBlock(@GetUserId() userId: number) {
+    return await this.friendsService.getBlock(userId);
   }
 
   @ApiGetRejectPermanent()

--- a/src/friends/controllers/friends.controller.ts
+++ b/src/friends/controllers/friends.controller.ts
@@ -21,6 +21,7 @@ import { ApiGetRejectPermanent } from '../swagger-decorators/get-reject-permanen
 import { ApiDeleteRejectPermanentCancel } from '../swagger-decorators/delete-reject-permanent-cancel.decorator';
 import { JwtAccessTokenGuard } from 'src/config/guards/jwt-access-token.guard';
 import { GetUserId } from 'src/common/decorators/get-userId.decorator';
+import { ApiDeleteRequest } from '../swagger-decorators/delete-request.decorator';
 
 @UseGuards(JwtAccessTokenGuard)
 @Controller('friends')
@@ -89,6 +90,15 @@ export class FriendsController {
       userId,
       friendId,
     );
+  }
+
+  @ApiDeleteRequest()
+  @Delete('requests/cancel/:friend_id')
+  async friendRequestCancel(
+    @GetUserId() userId: number,
+    @Param('friend_id') friendId: number,
+  ) {
+    return await this.friendsService.friendRequestCancel(userId, friendId);
   }
 
   @ApiDeleteRejectPermanentCancel()

--- a/src/friends/controllers/friends.controller.ts
+++ b/src/friends/controllers/friends.controller.ts
@@ -22,6 +22,7 @@ import { ApiDeleteRejectPermanentCancel } from '../swagger-decorators/delete-rej
 import { JwtAccessTokenGuard } from 'src/config/guards/jwt-access-token.guard';
 import { GetUserId } from 'src/common/decorators/get-userId.decorator';
 import { ApiDeleteRequest } from '../swagger-decorators/delete-request.decorator';
+import { ApiFriendBlock } from '../swagger-decorators/friend-block.decorator';
 
 @UseGuards(JwtAccessTokenGuard)
 @Controller('friends')
@@ -78,6 +79,15 @@ export class FriendsController {
     @Param('friend_id') friendId: number,
   ) {
     return await this.friendsService.friendResponseReject(userId, friendId);
+  }
+
+  @ApiFriendBlock()
+  @Patch('block/:friend_id')
+  async friendBlock(
+    @GetUserId() userId: number,
+    @Param('friend_id') friendId: number,
+  ) {
+    return await this.friendsService.friendBlock(userId, friendId);
   }
 
   @ApiFriendResponseRejectPermanent()

--- a/src/friends/controllers/friends.controller.ts
+++ b/src/friends/controllers/friends.controller.ts
@@ -23,6 +23,7 @@ import { JwtAccessTokenGuard } from 'src/config/guards/jwt-access-token.guard';
 import { GetUserId } from 'src/common/decorators/get-userId.decorator';
 import { ApiDeleteRequest } from '../swagger-decorators/delete-request.decorator';
 import { ApiFriendBlock } from '../swagger-decorators/friend-block.decorator';
+import { ApiDeleteBlock } from '../swagger-decorators/delete-block.decorator';
 
 @UseGuards(JwtAccessTokenGuard)
 @Controller('friends')
@@ -109,6 +110,15 @@ export class FriendsController {
     @Param('friend_id') friendId: number,
   ) {
     return await this.friendsService.friendRequestCancel(userId, friendId);
+  }
+
+  @ApiDeleteBlock()
+  @Delete('block/cancel/:friend_id')
+  async friendBlockCancel(
+    @GetUserId() userId: number,
+    @Param('friend_id') friendId: number,
+  ) {
+    return await this.friendsService.friendBlockCancel(userId, friendId);
   }
 
   @ApiDeleteRejectPermanentCancel()

--- a/src/friends/entities/friends.entity.ts
+++ b/src/friends/entities/friends.entity.ts
@@ -12,6 +12,7 @@ export enum Status {
   ACCEPT = '친구 수락',
   REJECT = '친구 거절',
   PERMANENT = '영구 거절',
+  BLOCK = '차단',
 }
 
 @Entity({ name: 'friend' })

--- a/src/friends/repositories/friends.repository.ts
+++ b/src/friends/repositories/friends.repository.ts
@@ -105,6 +105,30 @@ export class FriendsRepository {
     return await this.entityManager.save(friend);
   }
 
+  async friendBlock(userId: number, friendId: number): Promise<Friend> {
+    const friend = await this.entityManager.findOne(Friend, {
+      where: [
+        {
+          requesterId: userId,
+          respondentId: friendId,
+          status: Status.ACCEPT,
+        },
+        {
+          requesterId: friendId,
+          respondentId: userId,
+          status: Status.ACCEPT,
+        },
+      ],
+    });
+
+    if (!friend) {
+      return null;
+    }
+
+    friend.status = Status.BLOCK;
+    return await this.entityManager.save(friend);
+  }
+
   async friendRequestCancel(
     userId: number,
     friendId: number,

--- a/src/friends/repositories/friends.repository.ts
+++ b/src/friends/repositories/friends.repository.ts
@@ -49,6 +49,22 @@ export class FriendsRepository {
       .getMany();
   }
 
+  async getBlock(userId: number): Promise<Friend[]> {
+    return this.entityManager
+      .createQueryBuilder(Friend, 'friend')
+      .where('friend.requesterId = :userId', { userId })
+      .andWhere('friend.status = :status', { status: Status.BLOCK })
+      .orWhere('friend.respondentId = :userId', { userId })
+      .andWhere('friend.status = :status', { status: Status.BLOCK })
+      .leftJoin('friend.requester', 'user')
+      .leftJoin('friend.respondent', 'user2')
+      .leftJoin('user.userImage', 'userImage')
+      .leftJoin('user2.userImage', 'userImage2')
+      .addSelect(['user.name', 'userImage.imageUrl'])
+      .addSelect(['user2.name', 'userImage2.imageUrl'])
+      .getMany();
+  }
+
   async getRejectPermanent(userId: number): Promise<Friend[]> {
     return this.entityManager
       .createQueryBuilder(Friend, 'friend')

--- a/src/friends/repositories/friends.repository.ts
+++ b/src/friends/repositories/friends.repository.ts
@@ -244,6 +244,25 @@ export class FriendsRepository {
     return check;
   }
 
+  async checkBlock(userId: number, friendId: number): Promise<Friend> {
+    const check = await this.entityManager.findOne(Friend, {
+      where: [
+        {
+          requesterId: userId,
+          respondentId: friendId,
+          status: Status.BLOCK,
+        },
+        {
+          requesterId: friendId,
+          respondentId: userId,
+          status: Status.BLOCK,
+        },
+      ],
+    });
+
+    return check;
+  }
+
   async cleanupRejectedFriends() {
     const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 

--- a/src/friends/repositories/friends.repository.ts
+++ b/src/friends/repositories/friends.repository.ts
@@ -187,6 +187,32 @@ export class FriendsRepository {
     return await this.entityManager.delete(Friend, friend);
   }
 
+  async friendBlockCancel(
+    userId: number,
+    friendId: number,
+  ): Promise<DeleteResult> {
+    const friend = await this.entityManager.findOne(Friend, {
+      where: [
+        {
+          requesterId: userId,
+          respondentId: friendId,
+          status: Status.BLOCK,
+        },
+        {
+          requesterId: friendId,
+          respondentId: userId,
+          status: Status.BLOCK,
+        },
+      ],
+    });
+
+    if (!friend) {
+      return null;
+    }
+
+    return await this.entityManager.delete(Friend, friend);
+  }
+
   async friendResponseRejectPermanent(
     userId: number,
     friendId: number,

--- a/src/friends/repositories/friends.repository.ts
+++ b/src/friends/repositories/friends.repository.ts
@@ -105,6 +105,25 @@ export class FriendsRepository {
     return await this.entityManager.save(friend);
   }
 
+  async friendRequestCancel(
+    userId: number,
+    friendId: number,
+  ): Promise<DeleteResult> {
+    const friend = await this.entityManager.findOne(Friend, {
+      where: {
+        requesterId: userId,
+        respondentId: friendId,
+        status: Status.PENDING,
+      },
+    });
+
+    if (!friend) {
+      return null;
+    }
+
+    return await this.entityManager.delete(Friend, friend);
+  }
+
   async friendResponseReject(
     userId: number,
     friendId: number,

--- a/src/friends/services/friends.service.ts
+++ b/src/friends/services/friends.service.ts
@@ -126,6 +126,29 @@ export class FriendsService {
     }
   }
 
+  async friendBlock(userId: number, friendId: number) {
+    try {
+      const block = await this.friendsRepository.friendBlock(userId, friendId);
+      if (!block) {
+        throw new HttpException(
+          '친구를 찾을 수 없습니다.',
+          HttpStatus.NOT_FOUND,
+        );
+      }
+      return { message: '친구를 차단했습니다.' };
+    } catch (error) {
+      if (error.getStatus() === HttpStatus.NOT_FOUND) {
+        throw error;
+      } else {
+        console.log(error);
+        throw new HttpException(
+          '친구 차단에 실패했습니다.',
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+    }
+  }
+
   async friendRequestCancel(userId: number, friendId: number) {
     try {
       const cancel = await this.friendsRepository.friendRequestCancel(

--- a/src/friends/services/friends.service.ts
+++ b/src/friends/services/friends.service.ts
@@ -36,6 +36,17 @@ export class FriendsService {
         );
       }
 
+      const checkBlock = await this.friendsRepository.checkBlock(
+        userId,
+        friendId,
+      );
+      if (checkBlock) {
+        throw new HttpException(
+          '상대방이 친구를 차단했습니다.',
+          HttpStatus.GONE,
+        );
+      }
+
       const checkRejectTime = await this.friendsRepository.checkRejectTime(
         userId,
         friendId,
@@ -292,6 +303,25 @@ export class FriendsService {
       console.log(error);
       throw new HttpException(
         '영구 거절 체크에 실패했습니다.',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  async checkBlock(userId: number, friendId: number) {
+    try {
+      const checkBlock = await this.friendsRepository.checkBlock(
+        userId,
+        friendId,
+      );
+      if (!checkBlock) {
+        return false;
+      }
+      return true;
+    } catch (error) {
+      console.log(error);
+      throw new HttpException(
+        '차단 체크에 실패했습니다.',
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }

--- a/src/friends/services/friends.service.ts
+++ b/src/friends/services/friends.service.ts
@@ -19,6 +19,10 @@ export class FriendsService {
     return await this.friendsRepository.getFriends(userId);
   }
 
+  async getBlock(userId: number) {
+    return await this.friendsRepository.getBlock(userId);
+  }
+
   async getRejectPermanent(userId: number) {
     return await this.friendsRepository.getRejectPermanent(userId);
   }

--- a/src/friends/services/friends.service.ts
+++ b/src/friends/services/friends.service.ts
@@ -126,6 +126,32 @@ export class FriendsService {
     }
   }
 
+  async friendRequestCancel(userId: number, friendId: number) {
+    try {
+      const cancel = await this.friendsRepository.friendRequestCancel(
+        userId,
+        friendId,
+      );
+      if (!cancel) {
+        throw new HttpException(
+          '친구 요청을 찾을 수 없습니다.',
+          HttpStatus.NOT_FOUND,
+        );
+      }
+      return { message: '친구 요청을 취소했습니다.' };
+    } catch (error) {
+      if (error.getStatus() === HttpStatus.NOT_FOUND) {
+        throw error;
+      } else {
+        console.log(error);
+        throw new HttpException(
+          '친구 요청 취소에 실패했습니다.',
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+    }
+  }
+
   async friendResponseReject(userId: number, friendId: number) {
     try {
       const reject = await this.friendsRepository.friendResponseReject(

--- a/src/friends/services/friends.service.ts
+++ b/src/friends/services/friends.service.ts
@@ -238,6 +238,32 @@ export class FriendsService {
     }
   }
 
+  async friendBlockCancel(userId: number, friendId: number) {
+    try {
+      const blockCancel = await this.friendsRepository.friendBlockCancel(
+        userId,
+        friendId,
+      );
+      if (!blockCancel) {
+        throw new HttpException(
+          '친구 차단을 찾을 수 없습니다.',
+          HttpStatus.NOT_FOUND,
+        );
+      }
+      return { message: '친구 차단을 취소했습니다.' };
+    } catch (error) {
+      if (error.getStatus() === HttpStatus.NOT_FOUND) {
+        throw error;
+      } else {
+        console.log(error);
+        throw new HttpException(
+          '친구 차단 취소에 실패했습니다.',
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+    }
+  }
+
   async friendResponseRejectPermanent(userId: number, friendId: number) {
     try {
       const rejectPermanent =

--- a/src/friends/swagger-decorators/delete-block.decorator.ts
+++ b/src/friends/swagger-decorators/delete-block.decorator.ts
@@ -1,0 +1,77 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiHeaders, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiDeleteBlock() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '친구 차단 취소 API',
+      description: '친구 차단을 취소 합니다.',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 친구 차단을 취소한 경우',
+      content: {
+        JSON: { example: { message: '친구 차단을 취소했습니다.' } },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: '우리 서비스의 액세스 토큰이 아닌 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 401, message: '유효하지 않은 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 403,
+      description: '만료된 액세스 토큰인 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 403, message: '만료된 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '친구 차단을 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: {
+            statusCode: 404,
+            message: '친구 차단을 찾을 수 없습니다.',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 411,
+      description: '액세스 토큰이 제공되지 않은 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 411, message: '토큰이 제공되지 않았습니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 500,
+      description: '친구 차단 취소에 실패한 경우',
+      content: {
+        JSON: {
+          example: {
+            statusCode: 500,
+            message: '친구 차단 취소에 실패했습니다.',
+          },
+        },
+      },
+    }),
+    ApiHeaders([
+      {
+        name: 'access_token',
+        description: '액세스 토큰',
+        required: true,
+        example: '여기에 액세스 토큰',
+      },
+    ]),
+  );
+}

--- a/src/friends/swagger-decorators/delete-request.decorator.ts
+++ b/src/friends/swagger-decorators/delete-request.decorator.ts
@@ -1,0 +1,77 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiHeaders, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiDeleteRequest() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '친구 요청 취소 API',
+      description: '친구 요청을 취소합니다.',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 친구 요청을 취소한 경우',
+      content: {
+        JSON: { example: { message: '친구 요청을 취소했습니다.' } },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: '우리 서비스의 액세스 토큰이 아닌 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 401, message: '유효하지 않은 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 403,
+      description: '만료된 액세스 토큰인 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 403, message: '만료된 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '친구 요청을 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: {
+            statusCode: 404,
+            message: '친구 요청을 찾을 수 없습니다.',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 411,
+      description: '액세스 토큰이 제공되지 않은 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 411, message: '토큰이 제공되지 않았습니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 500,
+      description: '친구 요청 취소에 실패한 경우',
+      content: {
+        JSON: {
+          example: {
+            statusCode: 500,
+            message: '친구 요청 취소에 실패했습니다.',
+          },
+        },
+      },
+    }),
+    ApiHeaders([
+      {
+        name: 'access_token',
+        description: '액세스 토큰',
+        required: true,
+        example: '여기에 액세스 토큰',
+      },
+    ]),
+  );
+}

--- a/src/friends/swagger-decorators/friend-block.decorator.ts
+++ b/src/friends/swagger-decorators/friend-block.decorator.ts
@@ -1,0 +1,71 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiHeaders, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiFriendBlock() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '친구 차단 API',
+      description: '친구를 차단합니다.',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '성공적으로 친구를 차단한 경우',
+      content: {
+        JSON: { example: { message: '친구를 차단했습니다.' } },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: '우리 서비스의 액세스 토큰이 아닌 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 401, message: '유효하지 않은 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 403,
+      description: '만료된 액세스 토큰인 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 403, message: '만료된 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '친구를 찾을 수 없는 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 404, message: '친구를 찾을 수 없습니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 411,
+      description: '액세스 토큰이 제공되지 않은 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 411, message: '토큰이 제공되지 않았습니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 500,
+      description: '친구 차단에 실패한 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 500, message: '친구 차단에 실패했습니다.' },
+        },
+      },
+    }),
+    ApiHeaders([
+      {
+        name: 'access_token',
+        description: '액세스 토큰',
+        required: true,
+        example: '여기에 액세스 토큰',
+      },
+    ]),
+  );
+}

--- a/src/friends/swagger-decorators/get-friends-block.decorator.ts
+++ b/src/friends/swagger-decorators/get-friends-block.decorator.ts
@@ -1,0 +1,78 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiHeaders, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function ApiGetFriendsBlock() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '내가 차단한 친구 목록 조회 API',
+      description: '내가 차단한 친구 목록을 조회합니다.',
+    }),
+    ApiResponse({
+      status: 200,
+      description:
+        '성공적으로 친구 목록을 조회한 경우 (배열 형태) , 내가 차단한 친구가 없는 경우 빈 배열을 반환합니다.',
+      content: {
+        Array: {
+          example: [
+            {
+              id: 53,
+              requesterId: 62,
+              respondentId: 1,
+              status: '차단',
+              createdAt: '2023-11-15T21:13:13.000Z',
+              requester: {
+                name: '박준혁',
+                userImage: {
+                  imageUrl:
+                    'http://k.kakaocdn.net/dn/bgfjbT/btrNZpdv3sK/AMb1oWdaF6WxMEXkuKRkR0/img_640x640.jpg',
+                },
+              },
+              respondent: {
+                name: 'test',
+                userImage: {
+                  imageUrl:
+                    'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg',
+                },
+              },
+            },
+          ],
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: '우리 서비스의 액세스 토큰이 아닌 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 401, message: '유효하지 않은 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 403,
+      description: '만료된 액세스 토큰인 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 403, message: '만료된 토큰입니다.' },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 411,
+      description: '액세스 토큰이 제공되지 않은 경우',
+      content: {
+        JSON: {
+          example: { statusCode: 411, message: '토큰이 제공되지 않았습니다.' },
+        },
+      },
+    }),
+    ApiHeaders([
+      {
+        name: 'access_token',
+        description: '액세스 토큰',
+        required: true,
+        example: '여기에 액세스 토큰',
+      },
+    ]),
+  );
+}


### PR DESCRIPTION
### **⭐️중요 변경 사항⭐️**
friends.entity.ts 파일이 수정되었습니다.
`BLOCK = '차단'` << 추가됨.


```
import { User } from 'src/users/entities/user.entity';
import {
  Column,
  Entity,
  JoinColumn,
  ManyToOne,
  PrimaryGeneratedColumn,
} from 'typeorm';

export enum Status {
  PENDING = '대기 상태',
  ACCEPT = '친구 수락',
  REJECT = '친구 거절',
  PERMANENT = '영구 거절',
  BLOCK = '차단',
}

@Entity({ name: 'friend' })
export class Friend {
  @PrimaryGeneratedColumn()
  id: number;

  @Column({ name: 'requester_id' })
  requesterId: number;

  @Column({ name: 'respondent_id' })
  respondentId: number;

  @ManyToOne(() => User, (userId: User) => userId.requester, {
    onDelete: 'CASCADE',
  })
  @JoinColumn({ name: 'requester_id' })
  requester: User;

  @ManyToOne(() => User, (userId: User) => userId.respondent, {
    onDelete: 'CASCADE',
  })
  @JoinColumn({ name: 'respondent_id' })
  respondent: User;

  @Column({ type: 'enum', enum: Status, default: Status.PENDING })
  status!: Status;

  @Column({
    name: 'created_at',
    type: 'timestamp',
    default: () => 'CURRENT_TIMESTAMP',
  })
  createdAt: Date;
}

```

----------------------------------------------------------------------------------------------------------------------------

1. 친구 요청을 취소하는 API를 추가했습니다.
2. 친구를 차단하는 API 추가했습니다.
3. 친구 차단을 취소하는 API를 추가했습니다.