### PR TITLE
Refactor(2swo/board-user)Board-Gurad생성, 토큰 없을경우 예외처리

### DIFF
--- a/src/boards/controllers/Boards.controller.ts
+++ b/src/boards/controllers/Boards.controller.ts
@@ -17,7 +17,6 @@ import { BoardImagesService } from '../services/BoardImage.service';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { BoardResponseDTO } from '../dto/boards.response.dto';
 import { CreateBoardImageDto } from '../dto/create.board-image.dto';
-import { TokenService } from 'src/auth/services/token.service';
 import { ApiUploadBoardImages } from '../swagger-decorators/upload-baord-images-decorator';
 import { ApiAddBoard } from '../swagger-decorators/add-board-decorators';
 import { ApiGetPageBoards } from '../swagger-decorators/get-page-boards-decorators';
@@ -37,7 +36,6 @@ export class BoardsController {
   constructor(
     private readonly boardsService: BoardsService,
     private readonly boardImagesService: BoardImagesService,
-    private tokenService: TokenService,
   ) {}
 
   @Post('')

--- a/src/boards/controllers/Boards.controller.ts
+++ b/src/boards/controllers/Boards.controller.ts
@@ -28,7 +28,7 @@ import { ApiDeleteBoard } from '../swagger-decorators/delete-board-decorators';
 import { ApiUpdateBoardImage } from '../swagger-decorators/patch-board-images-decorators';
 import { JwtAccessTokenGuard } from 'src/config/guards/jwt-access-token.guard';
 import { GetUserId } from 'src/common/decorators/get-userId.decorator';
-import { BoardOwnerGuard } from 'src/config/guards/board-Owner.guard';
+import { BoardOwnerGuard } from 'src/config/guards/board-owner.guard';
 import { BoardOwner } from 'src/common/decorators/board-owner.decorator';
 
 @Controller('boards')

--- a/src/boards/controllers/Boards.controller.ts
+++ b/src/boards/controllers/Boards.controller.ts
@@ -96,7 +96,7 @@ export class BoardsController {
   }
 
   @Patch('/images')
-  @UseGuards()
+  @UseGuards(JwtAccessTokenGuard)
   @ApiUpdateBoardImage()
   @UseInterceptors(FilesInterceptor('files', 3))
   async editBoardImages(

--- a/src/boards/controllers/Boards.controller.ts
+++ b/src/boards/controllers/Boards.controller.ts
@@ -28,6 +28,8 @@ import { ApiDeleteBoard } from '../swagger-decorators/delete-board-decorators';
 import { ApiUpdateBoardImage } from '../swagger-decorators/patch-board-images-decorators';
 import { JwtAccessTokenGuard } from 'src/config/guards/jwt-access-token.guard';
 import { GetUserId } from 'src/common/decorators/get-userId.decorator';
+import { BoardOwnerGuard } from 'src/config/guards/board-Owner.guard';
+import { BoardOwner } from 'src/common/decorators/board-owner.decorator';
 
 @Controller('boards')
 @ApiTags('board API')
@@ -74,14 +76,15 @@ export class BoardsController {
   }
 
   @Get('/unit')
-  @UseGuards(JwtAccessTokenGuard)
+  @UseGuards(BoardOwnerGuard)
   @ApiGetOneBoard()
   async findOne(
     @Query('boardId') boardId: number,
+    @BoardOwner() unitOnwer: boolean,
     @GetUserId() userId: number,
   ): Promise<BoardResponseDTO> {
     ``;
-    return await this.boardsService.findOneBoard(boardId, userId);
+    return await this.boardsService.findOneBoard(boardId, userId, unitOnwer);
   }
 
   @Patch('')
@@ -94,7 +97,7 @@ export class BoardsController {
   }
 
   @Patch('/images')
-  @UseGuards(JwtAccessTokenGuard)
+  @UseGuards()
   @ApiUpdateBoardImage()
   @UseInterceptors(FilesInterceptor('files', 3))
   async editBoardImages(

--- a/src/boards/controllers/Boards.controller.ts
+++ b/src/boards/controllers/Boards.controller.ts
@@ -83,7 +83,6 @@ export class BoardsController {
     @BoardOwner() unitOnwer: boolean,
     @GetUserId() userId: number,
   ): Promise<BoardResponseDTO> {
-    ``;
     return await this.boardsService.findOneBoard(boardId, userId, unitOnwer);
   }
 

--- a/src/boards/services/Boards.service.ts
+++ b/src/boards/services/Boards.service.ts
@@ -62,9 +62,10 @@ export class BoardsService {
   async findOneBoard(
     boardId: number,
     userId: number,
+    unitOnwer: boolean,
   ): Promise<oneBoardResponseDTO> {
     const board = await this.boardRepository.findBoardById(boardId);
-    const unitowner = board.userId === userId;
+    const unitowner = unitOnwer;
     if (!board) {
       throw new Error('게시물을 찾을 수 없습니다.');
     }

--- a/src/common/decorators/board-owner.decorator.ts
+++ b/src/common/decorators/board-owner.decorator.ts
@@ -1,9 +1,9 @@
 import { ExecutionContext, createParamDecorator } from '@nestjs/common';
 
-export const GetUserId = createParamDecorator(
+export const BoardOwner = createParamDecorator(
   (data, ctx: ExecutionContext): number => {
     const req = ctx.switchToHttp().getRequest();
 
-    return req.user.userId;
+    return req.unitowner;
   },
 );

--- a/src/config/guards/board-owner.guard.ts
+++ b/src/config/guards/board-owner.guard.ts
@@ -1,0 +1,24 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { TokenService } from 'src/auth/services/token.service';
+import { BoardRepository } from 'src/boards/repository/boards.repository';
+
+@Injectable()
+export class BoardOwnerGuard {
+  constructor(
+    private tokenService: TokenService,
+    private boardRepository: BoardRepository,
+  ) {}
+
+  async canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+    const accessToken = request.headers['access_token'];
+    const boardId = request.query['boardId'];
+    const userId = await this.tokenService.decodeToken(accessToken);
+    const board = await this.boardRepository.findBoardById(boardId);
+    const unitowner = board.userId === userId;
+
+    request.unitowner = unitowner;
+    request.user = { userId };
+    return true;
+  }
+}

--- a/src/config/guards/board-owner.guard.ts
+++ b/src/config/guards/board-owner.guard.ts
@@ -13,6 +13,11 @@ export class BoardOwnerGuard {
     const request = context.switchToHttp().getRequest();
     const accessToken = request.headers['access_token'];
     const boardId = request.query['boardId'];
+    if (!accessToken) {
+      request.unitowner = false;
+      request.user = false;
+      return true;
+    }
     const userId = await this.tokenService.decodeToken(accessToken);
     const board = await this.boardRepository.findBoardById(boardId);
     const unitowner = board.userId === userId;


### PR DESCRIPTION
### 변경사항
 보드를 작성한 사용자인지 판별하는 코드와, accesstoken이 없어도 보드가 보여지게 하는 부분을 Guard로 설정했습니다
 

 ```javascript
 async canActivate(context: ExecutionContext) {
    const request = context.switchToHttp().getRequest();
    const accessToken = request.headers['access_token'];
    const boardId = request.query['boardId'];
    if (!accessToken) {  // 토큰 없을경우 예외처리
      request.unitowner = false; //unitowner는 자동으로 false처리
      request.user = false; //user도 false로 두기
      return true;
    }
    const userId = await this.tokenService.decodeToken(accessToken);
    const board = await this.boardRepository.findBoardById(boardId);
    const unitowner = board.userId === userId; //board의 userId와 토큰값 비교하기

    request.unitowner = unitowner;
    request.user = { userId };
    return true;
  }
```