### PR TITLE
fix(NicoDora/auth) : 리프레시 토큰 다시 로컬 스토리지에 저장하는 방식으로 변경

### DIFF
--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -52,14 +52,7 @@ export class AuthController {
       naverRefreshToken,
     );
 
-    res.cookie('refresh_token', refreshToken, {
-      httpOnly: true,
-      sameSite: 'Lax',
-      domain: 'localhost',
-      maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
-    });
-
-    return res.json({ accessToken });
+    return res.json({ accessToken, refreshToken });
   }
 
   @ApiKakaoLogin()
@@ -81,14 +74,7 @@ export class AuthController {
       kakaoRefreshToken,
     );
 
-    res.cookie('refresh_Token', refreshToken, {
-      httpOnly: true,
-      sameSite: 'Lax',
-      domain: 'localhost',
-      maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
-    });
-
-    return res.json({ accessToken });
+    return res.json({ accessToken, refreshToken });
   }
 
   @ApiCookieAuth('refresh-token')

--- a/src/config/guards/jwt-refresh-token.guard.ts
+++ b/src/config/guards/jwt-refresh-token.guard.ts
@@ -7,7 +7,7 @@ export class JwtRefreshTokenGuard {
 
   async canActivate(context: ExecutionContext) {
     const request = context.switchToHttp().getRequest();
-    const refreshToken = request.cookies['refresh_token'];
+    const refreshToken = request.headers['refresh_token'];
 
     if (!refreshToken) {
       return false;


### PR DESCRIPTION
리프레시 토큰을 쿠키에 저장하여 사용하려고 했지만 https 미적용 문제로 쿠키 적용이 되지 않아 개발에 불편함을 주어 다시 원래 로직대로 변경했습니다.